### PR TITLE
Update CI linting and pre-commit hooks, rustfmt 2024, test tweaks

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,62 @@
+## Codecov configuration for a Rust project
+#
+# This file tells Codecov how to post status checks and comments on
+# pull requests.  It lives in the root of the repository so that
+# Codecov can automatically pick it up.  According to Codecov’s
+# documentation, repository‑level configuration must be stored in a
+# `codecov.yml` or `.codecov.yml` file at the root, `dev/`, or
+# `.github/` directory of the repository.
+
+# Show a project‑wide coverage status on every pull request.  By
+# default Codecov only posts coverage for the lines changed in the PR
+# (“patch” coverage).  The `coverage.status.project` section below
+# enables an additional status check for the entire project.  Setting
+# `target: auto` means the required coverage is based on the base
+# commit’s coverage; `threshold: 0%` means no drop in coverage is
+# tolerated; and `base: auto` makes Codecov choose the correct base
+# commit.
+coverage:
+  status:
+    project:
+      default:
+        # Use the base commit’s coverage as the target.  This causes
+        # Codecov to flag decreases in overall coverage on a pull
+        # request.  You can change this to a fixed number (e.g. 80%)
+        # if your project has a minimum coverage requirement.
+        target: auto
+        # Allow no percentage drop from the target; increase this if
+        # minor drops should still pass.  Thresholds are specified as
+        # percentages (e.g. 1% would allow the coverage to drop by
+        # one percentage point).
+        threshold: 0%
+        # Use Codecov’s default base selection for comparisons.  The
+        # `base` key is deprecated but remains in examples to clarify
+        # behavior.
+        base: auto
+
+# Configure the pull request comment so that Codecov includes project
+# coverage information.  Without this, the comment only shows the
+# coverage of the changed lines.  The options below follow the
+# example in Codecov’s common configuration recipes:
+comment:
+  # The order in which information is shown in the PR comment.  The
+  # "diff" section shows changes to lines in the pull request, the
+  # "flags" section lists flag‑specific coverage if you use flags, and
+  # the "files" section lists files and their coverage.  Including
+  # "files" ensures that project‑wide coverage appears in the comment.
+  layout: "diff, flags, files"
+  # Use default behavior; this means Codecov will always post a
+  # comment when coverage reports are uploaded.
+  behavior: default
+  # Post the comment even if coverage did not change.  Set this to
+  # true if you only want comments on coverage changes.
+  require_changes: false
+  # Allow comments when no base coverage report exists.
+  require_base: false
+  # Require a coverage report on the head commit before posting a
+  # comment.
+  require_head: true
+  # Show project coverage in the comment.  Setting this to true hides
+  # project coverage and only shows the patch coverage; leaving it
+  # false makes the project coverage visible.
+  hide_project_coverage: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,23 +47,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rs/toolchain@v1
         with:
+          toolchain: stable
           components: clippy
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          override: true
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --tests -- -F clippy::pedantic
+          args: "--all-features --tests -- -F clippy::pedantic"
+          name: Clippy Output
 
   audit:
     name: Security Audit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ env:
 
 jobs:
   test:
-    name: Test ${{ matrix.rust }} on ${{ matrix.os }}
+    name: Test ${{ matrix.rust }} on ${{ matrix.os }} ${{ matrix.feature }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -32,13 +32,14 @@ jobs:
         run: cargo test --workspace ${{ matrix.feature }}
 
   coverage:
-    name: Code coverage
+    name: Code coverage (ubuntu + stable + default features)
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Install Rust toolchain
+      - name: Install Rust toolchain (stable + llvm-tools)
         uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,15 @@
 name: Test
-on: [push, pull_request]
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/**/*"
+      - "tests/**/*"
+      - ".github/workflows/test.yml"
+  push:
+    paths:
+      - ".github/workflows/test.yml"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+repos:
+  - repo: local
+    hooks:
+      - id: fmt
+        name: fmt
+        entry: cargo
+        args:
+          - --quiet
+          - fmt
+          - --
+          - --color
+          - never
+          - --quiet
+          - --files-with-diff
+        language: system
+        types: [file, rust]
+        stages: [pre-commit]
+      - id: check
+        name: check
+        entry: cargo
+        args:
+          - --quiet
+          - check
+          - --color
+          - never
+          - --tests
+        language: system
+        types: [file, rust]
+        pass_filenames: false
+        stages: [pre-commit]
+      - id: clippy
+        name: clippy
+        entry: cargo
+        args:
+          - clippy
+          - --all-features
+          - --tests
+          - --
+          - -F
+          - "clippy::pedantic"
+        language: system
+        types: [file, rust]
+        pass_filenames: false
+        stages: [pre-push]

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,2 @@
 max_width=80
+style_edition="2024"

--- a/src/core/parser/lexer.rs
+++ b/src/core/parser/lexer.rs
@@ -826,7 +826,12 @@ impl TokenRecognizer for IdentifierRecognizer {
                     start: pos.clone(),
                     end: pos,
                 };
-                return Err(LexError::new(format!("Default parser does not support non-ASCII characters in identifiers (found \"{ch}\")"),span) );
+                return Err(LexError::new(
+                    format!(
+                        "Default parser does not support non-ASCII characters in identifiers (found \"{ch}\")"
+                    ),
+                    span,
+                ));
             }
             if ch.is_alphanumeric() || ch == '_' {
                 identifier.push(ch);
@@ -908,6 +913,7 @@ impl Lexer {
 
 #[cfg(test)]
 mod tests {
+    #![expect(clippy::unwrap_used)]
     use super::*;
 
     #[test]
@@ -1196,9 +1202,11 @@ mod tests {
     fn test_unicode_characters() {
         let mut lexer = Lexer::default_for_input("non_asciî");
         assert!(lexer.next_token().is_err());
-        assert!(lexer
-            .next_token()
-            .is_err_and(|LexError { message, .. }| message.contains('î')));
+        assert!(
+            lexer
+                .next_token()
+                .is_err_and(|LexError { message, .. }| message.contains('î'))
+        );
     }
 
     #[test]
@@ -1405,8 +1413,10 @@ mod tests {
             "relation" , "title"    , "User"          ,
         ];
         for identifier in expected_identifiers {
-            assert!(token_types
-                .contains(&&TokenType::Identifier(identifier.to_owned())));
+            assert!(
+                token_types
+                    .contains(&&TokenType::Identifier(identifier.to_owned()))
+            );
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Updated CI: explicit permissions, new Rust toolchain action, removed separate cache step, clearer test/coverage job names and ordering.
  * Integrated Codecov to show project coverage on PRs with detailed comments.
  * Added pre-commit hooks for formatting, checks, and Clippy (including pedantic) to enforce code quality.
* Style
  * Adopted Rustfmt 2024 style edition while keeping existing width; reformatted code.
* Tests
  * Added Clippy lint expectations in test modules and adjusted assertion formatting without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->