### PR TITLE
Fix parser literal handling and recovery

### DIFF
--- a/src/core/parser/components/declarations.rs
+++ b/src/core/parser/components/declarations.rs
@@ -144,6 +144,14 @@ impl Parser<ModelDecl> for ModelParser {
         let mut member_parser = ModelMemberParser;
 
         while !stream.check(TokenType::RightBrace) && !stream.is_at_end() {
+            if matches!(
+                stream.peek().map(Token::r#type),
+                Some(TokenType::Comment(_))
+            ) {
+                stream.next();
+                continue;
+            }
+
             if member_parser.can_parse(stream) {
                 let mut res = member_parser.parse(stream, options);
                 diags.append(&mut res.diagnostics);
@@ -294,6 +302,14 @@ impl Parser<EnumDecl> for EnumParser {
         let mut member_parser = EnumMemberParser;
 
         while !stream.check(TokenType::RightBrace) && !stream.is_at_end() {
+            if matches!(
+                stream.peek().map(Token::r#type),
+                Some(TokenType::Comment(_))
+            ) {
+                stream.next();
+                continue;
+            }
+
             if member_parser.can_parse(stream) {
                 let mut res = member_parser.parse(stream, options);
                 diags.append(&mut res.diagnostics);
@@ -444,6 +460,14 @@ impl Parser<DatasourceDecl> for DatasourceParser {
         let mut assignment_parser = AssignmentParser;
 
         while !stream.check(TokenType::RightBrace) && !stream.is_at_end() {
+            if matches!(
+                stream.peek().map(Token::r#type),
+                Some(TokenType::Comment(_))
+            ) {
+                stream.next();
+                continue;
+            }
+
             if assignment_parser.can_parse(stream) {
                 let mut res = assignment_parser.parse(stream, options);
                 diags.append(&mut res.diagnostics);
@@ -583,6 +607,14 @@ impl Parser<GeneratorDecl> for GeneratorParser {
         let mut assignment_parser = AssignmentParser;
 
         while !stream.check(TokenType::RightBrace) && !stream.is_at_end() {
+            if matches!(
+                stream.peek().map(Token::r#type),
+                Some(TokenType::Comment(_))
+            ) {
+                stream.next();
+                continue;
+            }
+
             if assignment_parser.can_parse(stream) {
                 let mut res = assignment_parser.parse(stream, options);
                 diags.append(&mut res.diagnostics);

--- a/src/core/parser/components/expressions.rs
+++ b/src/core/parser/components/expressions.rs
@@ -5,7 +5,9 @@
 //! Spans are preserved, comments are ignored for lookahead where relevant,
 //! and trailing commas are accepted in arrays and objects.
 
-use crate::core::parser::components::primitives::QualifiedIdentParser;
+use crate::core::parser::components::{
+    attributes::ArgListParser, primitives::QualifiedIdentParser,
+};
 use crate::core::parser::stream::TokenStreamExt;
 use crate::core::parser::{
     ast::{
@@ -119,6 +121,27 @@ impl ExpressionParser {
                 "Unexpected end of input",
             ))
         }
+    }
+
+    /// Return whether a literal token payload encodes a bool or null literal.
+    #[must_use]
+    fn is_bool_or_null(value: &str) -> bool {
+        matches!(value, "true" | "false" | "null")
+    }
+
+    /// Return whether a literal token payload should be treated as a string.
+    ///
+    /// The scanner strips surrounding quotes from string literals, so parser
+    /// classification cannot rely on quote characters being present.
+    #[must_use]
+    fn is_string_literal(value: &str) -> bool {
+        !Self::is_numeric(value) && !Self::is_bool_or_null(value)
+    }
+
+    /// Return whether a token can start an identifier reference or function call.
+    #[must_use]
+    fn is_ident_like_token(token_type: &TokenType) -> bool {
+        matches!(token_type, TokenType::Identifier(_) | TokenType::Type)
     }
 
     /// Parse a numeric literal efficiently.
@@ -263,8 +286,8 @@ impl ExpressionParser {
         };
 
         match token.r#type() {
-            // String literals - fast path
-            TokenType::Literal(value) if value.starts_with('"') => {
+            // String literals
+            TokenType::Literal(value) if Self::is_string_literal(value) => {
                 Self::parse_string_literal(stream)
             }
 
@@ -274,9 +297,7 @@ impl ExpressionParser {
             }
 
             // Boolean and null literals (stored as TokenType::Literal)
-            TokenType::Literal(value)
-                if matches!(value.as_str(), "true" | "false" | "null") =>
-            {
+            TokenType::Literal(value) if Self::is_bool_or_null(value) => {
                 Self::parse_bool_or_null_literal(stream)
             }
 
@@ -291,8 +312,19 @@ impl ExpressionParser {
                 self.parse_parenthesized_expr(stream, options)
             }
 
+            // Empty-array literal represented by the scanner as a single `[]` token
+            TokenType::List => {
+                let token = stream
+                    .next()
+                    .expect("peek returned Some but next returned None");
+                ParseResult::success(Expr::Array(ArrayExpr {
+                    elements: Vec::new(),
+                    span: token.span().clone(),
+                }))
+            }
+
             // Identifiers - could be simple references or function calls
-            TokenType::Identifier(_) => {
+            token_type if Self::is_ident_like_token(token_type) => {
                 self.parse_ident_or_func_call(stream, options)
             }
 
@@ -303,153 +335,58 @@ impl ExpressionParser {
         }
     }
 
-    /// Parse function arguments efficiently.
-    fn parse_function_args(
-        &mut self,
-        stream: &mut dyn TokenStream,
-        options: &ParserOptions,
-    ) -> ParseResult<Option<crate::core::parser::ast::ArgList>> {
-        // Parse arguments efficiently - preallocate for common case
-        let mut args = Vec::with_capacity(4);
-
-        // Parse argument list
-        loop {
-            let Some(token) = stream.peek() else {
-                break;
-            };
-
-            if matches!(token.r#type(), TokenType::RightParen) {
-                break;
-            }
-
-            if !args.is_empty() {
-                // Expect comma between arguments
-                if !matches!(token.r#type(), TokenType::Comma) {
-                    return ParseResult::error(Diagnostic::error(
-                        token.span().clone(),
-                        "Expected ',' between function arguments",
-                    ));
-                }
-                stream.next(); // consume comma
-
-                // Check for trailing comma
-                if let Some(next_token) = stream.peek()
-                    && matches!(next_token.r#type(), TokenType::RightParen)
-                {
-                    break;
-                }
-            }
-
-            // Parse the argument expression
-            match self.parse(stream, options) {
-                ParseResult {
-                    value: Some(expr),
-                    diagnostics: _arg_diags,
-                } => {
-                    args.push(crate::core::parser::ast::Arg::Positional(
-                        crate::core::parser::ast::PositionalArg {
-                            span: expr.span().clone(),
-                            value: expr,
-                        },
-                    ));
-                }
-                ParseResult {
-                    value: None,
-                    diagnostics: _arg_diags,
-                } => {
-                    return ParseResult::error(Diagnostic::error(
-                        stream.peek().map_or_else(
-                            || SymbolSpan {
-                                start: crate::core::scanner::tokens::SymbolLocation { line: 1, column: 1 },
-                                end: crate::core::scanner::tokens::SymbolLocation { line: 1, column: 1 },
-                            },
-                            |t| t.span().clone()
-                        ),
-                        "Expected expression in function argument",
-                    ));
-                }
-            }
-        }
-
-        if args.is_empty() {
-            ParseResult::success(None)
-        } else {
-            // Create span from first to last arg
-            let start_span = args[0].span().start.clone();
-            let end_span = args[args.len() - 1].span().end.clone();
-            ParseResult::success(Some(crate::core::parser::ast::ArgList {
-                items: args,
-                span: SymbolSpan {
-                    start: start_span,
-                    end: end_span,
-                },
-            }))
-        }
-    }
-
     fn parse_func_call(
         &mut self,
         stream: &mut dyn TokenStream,
         options: &ParserOptions,
         name: crate::core::parser::ast::QualifiedIdent,
         start_span: crate::core::scanner::tokens::SymbolLocation,
-        diagnostics: Vec<Diagnostic>,
+        mut diagnostics: Vec<Diagnostic>,
     ) -> ParseResult<Expr> {
-        // Parse as function call
-        stream.next(); // consume '('
-
-        let args_result = self.parse_function_args(stream, options);
-
-        // Expect closing parenthesis
-        match stream.peek() {
-            Some(token) if matches!(token.r#type(), TokenType::RightParen) => {
-                if let Some(close_token) = stream.next() {
-                    let end_span = close_token.span().end.clone();
-
-                    let func_span = SymbolSpan {
-                        start: start_span,
-                        end: end_span,
-                    };
-                    let arg_list = match args_result {
-                        ParseResult {
-                            value: Some(args),
-                            diagnostics: _,
-                        } => args,
-                        ParseResult {
-                            value: None,
-                            diagnostics: _,
-                        } => None,
-                    };
-
-                    let mut result =
-                        ParseResult::success(Expr::FuncCall(FuncCall {
-                            callee: name,
-                            args: arg_list,
-                            span: func_span,
-                        }));
-                    result.diagnostics = diagnostics;
-                    result
+        let mut arg_list_parser = ArgListParser::new();
+        match arg_list_parser.parse(stream, options) {
+            ParseResult {
+                value: Some(args),
+                diagnostics: mut arg_diags,
+            } => {
+                let func_span = SymbolSpan {
+                    start: start_span,
+                    end: args.span.end.clone(),
+                };
+                let arg_list = if args.items.is_empty() {
+                    None
                 } else {
-                    ParseResult::error(Diagnostic::error(
-                        SymbolSpan {
+                    Some(args)
+                };
+
+                diagnostics.append(&mut arg_diags);
+                let mut result =
+                    ParseResult::success(Expr::FuncCall(FuncCall {
+                        callee: name,
+                        args: arg_list,
+                        span: func_span,
+                    }));
+                result.diagnostics = diagnostics;
+                result
+            }
+            ParseResult {
+                value: None,
+                diagnostics: mut arg_diags,
+            } => {
+                diagnostics.append(&mut arg_diags);
+                let mut result = ParseResult::error(Diagnostic::error(
+                    stream.peek().map_or_else(
+                        || SymbolSpan {
                             start: start_span.clone(),
                             end: start_span,
                         },
-                        "Unexpected end of input, expected ')'",
-                    ))
-                }
+                        |t| t.span().clone(),
+                    ),
+                    "Failed to parse function arguments",
+                ));
+                result.diagnostics = diagnostics;
+                result
             }
-            Some(token) => ParseResult::error(Diagnostic::error(
-                token.span().clone(),
-                "Expected ')' after function arguments",
-            )),
-            None => ParseResult::error(Diagnostic::error(
-                SymbolSpan {
-                    start: start_span.clone(),
-                    end: start_span,
-                },
-                "Unexpected end of input, expected ')'",
-            )),
         }
     }
 
@@ -673,20 +610,19 @@ impl ExpressionParser {
         stream: &mut dyn TokenStream,
     ) -> ParseResult<ObjectKey> {
         match stream.peek() {
-            Some(token)
-                if matches!(token.r#type(), TokenType::Identifier(_)) =>
-            {
+            Some(token) if Self::is_ident_like_token(token.r#type()) => {
                 if let Some(token) = stream.next() {
-                    if let TokenType::Identifier(text) = token.r#type() {
-                        ParseResult::success(ObjectKey::Ident(
-                            crate::core::parser::ast::Ident {
-                                text: text.clone(),
-                                span: token.span().clone(),
-                            },
-                        ))
-                    } else {
-                        unreachable!("Token type was checked")
-                    }
+                    let text = match token.r#type() {
+                        TokenType::Identifier(text) => text.clone(),
+                        TokenType::Type => "type".to_string(),
+                        _ => unreachable!("Token type was checked"),
+                    };
+                    ParseResult::success(ObjectKey::Ident(
+                        crate::core::parser::ast::Ident {
+                            text,
+                            span: token.span().clone(),
+                        },
+                    ))
                 } else {
                     ParseResult::error(Diagnostic::error(
                         SymbolSpan {
@@ -704,7 +640,7 @@ impl ExpressionParser {
                     ))
                 }
             }
-            Some(token) if matches!(token.r#type(), TokenType::Literal(value) if value.starts_with('"')) => {
+            Some(token) if matches!(token.r#type(), TokenType::Literal(value) if Self::is_string_literal(value)) => {
                 if let Some(token) = stream.next() {
                     if let TokenType::Literal(value) = token.r#type() {
                         let unquoted = if value.len() >= 2
@@ -1004,6 +940,8 @@ impl Parser<Expr> for ExpressionParser {
             Some(
                 TokenType::Literal(_)
                     | TokenType::Identifier(_)
+                    | TokenType::Type
+                    | TokenType::List
                     | TokenType::LeftBracket
                     | TokenType::LeftBrace
                     | TokenType::LeftParen
@@ -1043,6 +981,24 @@ mod tests {
         let tokens = vec![create_test_token(TokenType::Literal(
             "\"hello\"".to_string(),
         ))];
+        let mut stream = VectorTokenStream::new(tokens);
+        let mut parser = ExpressionParser::new();
+        let options = ParserOptions::default();
+
+        let result = parser.parse(&mut stream, &options);
+
+        assert!(result.is_success());
+        if let Some(Expr::StringLit(lit)) = result.value {
+            assert_eq!(lit.value, "hello");
+        } else {
+            panic!("Expected string literal");
+        }
+    }
+
+    #[test]
+    fn scanner_style_string_literal_without_quotes() {
+        let tokens =
+            vec![create_test_token(TokenType::Literal("hello".to_string()))];
         let mut stream = VectorTokenStream::new(tokens);
         let mut parser = ExpressionParser::new();
         let options = ParserOptions::default();
@@ -1264,6 +1220,32 @@ mod tests {
     }
 
     #[test]
+    fn function_call_with_named_args() {
+        let tokens = vec![
+            create_test_token(TokenType::Identifier("createdAt".to_string())),
+            create_test_token(TokenType::LeftParen),
+            create_test_token(TokenType::Identifier("sort".to_string())),
+            create_test_token(TokenType::Colon),
+            create_test_token(TokenType::Identifier("Desc".to_string())),
+            create_test_token(TokenType::RightParen),
+        ];
+        let mut stream = VectorTokenStream::new(tokens);
+        let mut parser = ExpressionParser::new();
+        let options = ParserOptions::default();
+
+        let result = parser.parse(&mut stream, &options);
+
+        assert!(result.is_success());
+        if let Some(Expr::FuncCall(call)) = result.value {
+            assert_eq!(call.callee.parts[0].text, "createdAt");
+            assert!(call.args.is_some());
+            assert_eq!(call.args.as_ref().unwrap().items.len(), 1);
+        } else {
+            panic!("Expected function call with named arguments");
+        }
+    }
+
+    #[test]
     fn empty_array() {
         let tokens = vec![
             create_test_token(TokenType::LeftBracket),
@@ -1344,6 +1326,33 @@ mod tests {
         assert!(result.is_success());
         if let Some(Expr::Object(obj)) = result.value {
             assert_eq!(obj.entries.len(), 1);
+        } else {
+            panic!("Expected object expression");
+        }
+    }
+
+    #[test]
+    fn object_with_scanner_style_string_key() {
+        let tokens = vec![
+            create_test_token(TokenType::LeftBrace),
+            create_test_token(TokenType::Literal("key".to_string())),
+            create_test_token(TokenType::Colon),
+            create_test_token(TokenType::Literal("1".to_string())),
+            create_test_token(TokenType::RightBrace),
+        ];
+        let mut stream = VectorTokenStream::new(tokens);
+        let mut parser = ExpressionParser::new();
+        let options = ParserOptions::default();
+
+        let result = parser.parse(&mut stream, &options);
+
+        assert!(result.is_success());
+        if let Some(Expr::Object(obj)) = result.value {
+            assert_eq!(obj.entries.len(), 1);
+            assert!(matches!(
+                obj.entries[0].key,
+                crate::core::parser::ast::ObjectKey::String(_)
+            ));
         } else {
             panic!("Expected object expression");
         }

--- a/src/core/parser/components/expressions.rs
+++ b/src/core/parser/components/expressions.rs
@@ -917,10 +917,54 @@ impl ExpressionParser {
     /// Fast numeric detection without regex.
     #[must_use]
     pub fn is_numeric(value: &str) -> bool {
-        !value.is_empty()
-            && (value.chars().all(|c| c.is_ascii_digit())
-                || (value.contains('.')
-                    && value.chars().all(|c| c.is_ascii_digit() || c == '.')))
+        if value.is_empty() {
+            return false;
+        }
+
+        let bytes = value.as_bytes();
+        let mut idx = 0usize;
+
+        if bytes[idx] == b'-' {
+            idx += 1;
+            if idx == bytes.len() {
+                return false;
+            }
+        }
+
+        let int_start = idx;
+        while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+            idx += 1;
+        }
+        if idx == int_start {
+            return false;
+        }
+
+        if idx < bytes.len() && bytes[idx] == b'.' {
+            idx += 1;
+            let frac_start = idx;
+            while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+                idx += 1;
+            }
+            if idx == frac_start {
+                return false;
+            }
+        }
+
+        if idx < bytes.len() && matches!(bytes[idx], b'e' | b'E') {
+            idx += 1;
+            if idx < bytes.len() && matches!(bytes[idx], b'+' | b'-') {
+                idx += 1;
+            }
+            let exp_start = idx;
+            while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+                idx += 1;
+            }
+            if idx == exp_start {
+                return false;
+            }
+        }
+
+        idx == bytes.len()
     }
 }
 
@@ -1032,6 +1076,20 @@ mod tests {
     }
 
     #[test]
+    fn signed_integer_literal_is_not_classified_as_string() {
+        let tokens =
+            vec![create_test_token(TokenType::Literal("-1".to_string()))];
+        let mut stream = VectorTokenStream::new(tokens);
+        let mut parser = ExpressionParser::new();
+        let options = ParserOptions::default();
+
+        let result = parser.parse(&mut stream, &options);
+
+        assert!(result.is_success());
+        assert!(matches!(result.value, Some(Expr::IntLit(_))));
+    }
+
+    #[test]
     fn float_literal() {
         let tokens =
             vec![create_test_token(TokenType::Literal("3.14".to_string()))];
@@ -1047,6 +1105,20 @@ mod tests {
         } else {
             panic!("Expected float literal");
         }
+    }
+
+    #[test]
+    fn scientific_literal_is_not_classified_as_string() {
+        let tokens =
+            vec![create_test_token(TokenType::Literal("1e10".to_string()))];
+        let mut stream = VectorTokenStream::new(tokens);
+        let mut parser = ExpressionParser::new();
+        let options = ParserOptions::default();
+
+        let result = parser.parse(&mut stream, &options);
+
+        assert!(result.is_success());
+        assert!(matches!(result.value, Some(Expr::IntLit(_))));
     }
 
     #[test]
@@ -1436,8 +1508,15 @@ mod tests {
         assert!(ExpressionParser::is_numeric("42"));
         assert!(ExpressionParser::is_numeric("3.14"));
         assert!(ExpressionParser::is_numeric("0"));
+        assert!(ExpressionParser::is_numeric("-1"));
+        assert!(ExpressionParser::is_numeric("1e10"));
+        assert!(ExpressionParser::is_numeric("-1e10"));
+        assert!(ExpressionParser::is_numeric("1.0e+10"));
         assert!(!ExpressionParser::is_numeric("hello"));
         assert!(!ExpressionParser::is_numeric(""));
+        assert!(!ExpressionParser::is_numeric("1."));
+        assert!(!ExpressionParser::is_numeric("1e"));
+        assert!(!ExpressionParser::is_numeric("-"));
         assert!(!ExpressionParser::is_numeric("42a"));
     }
 

--- a/src/core/parser/components/expressions.rs
+++ b/src/core/parser/components/expressions.rs
@@ -314,13 +314,27 @@ impl ExpressionParser {
 
             // Empty-array literal represented by the scanner as a single `[]` token
             TokenType::List => {
-                let token = stream
-                    .next()
-                    .expect("peek returned Some but next returned None");
-                ParseResult::success(Expr::Array(ArrayExpr {
-                    elements: Vec::new(),
-                    span: token.span().clone(),
-                }))
+                if let Some(token) = stream.next() {
+                    ParseResult::success(Expr::Array(ArrayExpr {
+                        elements: Vec::new(),
+                        span: token.span().clone(),
+                    }))
+                } else {
+                    ParseResult::error(Diagnostic::error(
+                        SymbolSpan {
+                            start:
+                                crate::core::scanner::tokens::SymbolLocation {
+                                    line: 1,
+                                    column: 1,
+                                },
+                            end: crate::core::scanner::tokens::SymbolLocation {
+                                line: 1,
+                                column: 1,
+                            },
+                        },
+                        "Unexpected end of input, expected list literal",
+                    ))
+                }
             }
 
             // Identifiers - could be simple references or function calls
@@ -336,7 +350,6 @@ impl ExpressionParser {
     }
 
     fn parse_func_call(
-        &mut self,
         stream: &mut dyn TokenStream,
         options: &ParserOptions,
         name: crate::core::parser::ast::QualifiedIdent,
@@ -408,7 +421,7 @@ impl ExpressionParser {
                 if let Some(token) = stream.peek()
                     && matches!(token.r#type(), TokenType::LeftParen)
                 {
-                    self.parse_func_call(
+                    Self::parse_func_call(
                         stream,
                         options,
                         name,

--- a/src/core/parser/components/helpers.rs
+++ b/src/core/parser/components/helpers.rs
@@ -32,9 +32,9 @@ pub(crate) fn span_from_to(a: &SymbolSpan, b: &SymbolSpan) -> SymbolSpan {
 pub fn extract_doc_text(token: &Token) -> Option<String> {
     if let TokenType::DocComment(text) = token.r#type() {
         if let Some(rest) = text.strip_prefix(' ') {
-            Some(rest.to_string())
+            Some(rest.to_owned())
         } else {
-            Some(text.to_string())
+            Some(text.clone())
         }
     } else {
         None

--- a/src/core/parser/components/members.rs
+++ b/src/core/parser/components/members.rs
@@ -37,6 +37,10 @@ fn ident_from_token(tok: &Token) -> Option<Ident> {
             text: s.clone(),
             span: tspan(tok),
         }),
+        TokenType::Type => Some(Ident {
+            text: "type".to_string(),
+            span: tspan(tok),
+        }),
         _ => None,
     }
 }
@@ -157,7 +161,7 @@ impl Parser<Assignment> for AssignmentParser {
         if let (Some(cur), Some(next)) =
             (stream.peek_non_comment(), stream.peek_ahead_non_comment(1))
         {
-            matches!(cur.r#type(), TokenType::Identifier(_))
+            matches!(cur.r#type(), TokenType::Identifier(_) | TokenType::Type)
                 && matches!(next.r#type(), TokenType::Assign)
         } else {
             false
@@ -248,9 +252,9 @@ impl Parser<EnumValue> for EnumValueParser {
     }
 
     fn can_parse(&self, stream: &dyn TokenStream) -> bool {
-        stream
-            .peek_non_comment()
-            .is_some_and(|t| matches!(t.r#type(), TokenType::Identifier(_)))
+        stream.peek_non_comment().is_some_and(|t| {
+            matches!(t.r#type(), TokenType::Identifier(_) | TokenType::Type)
+        })
     }
 
     fn sync_tokens(&self) -> &[TokenType] {
@@ -431,9 +435,9 @@ impl Parser<FieldDecl> for FieldDeclParser {
     }
 
     fn can_parse(&self, stream: &dyn TokenStream) -> bool {
-        stream
-            .peek_non_comment()
-            .is_some_and(|t| matches!(t.r#type(), TokenType::Identifier(_)))
+        stream.peek_non_comment().is_some_and(|t| {
+            matches!(t.r#type(), TokenType::Identifier(_) | TokenType::Type)
+        })
     }
 
     fn sync_tokens(&self) -> &[TokenType] {
@@ -508,7 +512,12 @@ impl Parser<ModelMember> for ModelMemberParser {
 
     fn can_parse(&self, stream: &dyn TokenStream) -> bool {
         if let Some(t) = stream.peek_non_comment() {
-            matches!(t.r#type(), TokenType::Identifier(_) | TokenType::DoubleAt)
+            matches!(
+                t.r#type(),
+                TokenType::Identifier(_)
+                    | TokenType::Type
+                    | TokenType::DoubleAt
+            )
         } else {
             false
         }
@@ -588,7 +597,12 @@ impl Parser<EnumMember> for EnumMemberParser {
 
     fn can_parse(&self, stream: &dyn TokenStream) -> bool {
         if let Some(t) = stream.peek_non_comment() {
-            matches!(t.r#type(), TokenType::Identifier(_) | TokenType::DoubleAt)
+            matches!(
+                t.r#type(),
+                TokenType::Identifier(_)
+                    | TokenType::Type
+                    | TokenType::DoubleAt
+            )
         } else {
             false
         }

--- a/src/core/parser/components/primitives.rs
+++ b/src/core/parser/components/primitives.rs
@@ -46,6 +46,17 @@ use crate::core::parser::{
 };
 use crate::core::scanner::tokens::{SymbolSpan, TokenType};
 
+/// Return identifier text for tokens that are valid in identifier position.
+fn identifier_text(token_type: &TokenType) -> Option<&str> {
+    match token_type {
+        TokenType::Identifier(text) => Some(text),
+        // `type` is a contextual keyword in Prisma and can still appear
+        // in identifier-like positions such as field names and references.
+        TokenType::Type => Some("type"),
+        _ => None,
+    }
+}
+
 /// Parse a single identifier into an `Ident` AST node.
 ///
 /// Returns the identifier text and its span. `can_parse` ignores leading
@@ -89,13 +100,11 @@ impl Parser<Ident> for IdentParser {
         _options: &ParserOptions,
     ) -> ParseResult<Ident> {
         match stream.peek() {
-            Some(token)
-                if matches!(token.r#type(), TokenType::Identifier(_)) =>
-            {
+            Some(token) if identifier_text(token.r#type()).is_some() => {
                 if let Some(token) = stream.next() {
-                    if let TokenType::Identifier(text) = token.r#type() {
+                    if let Some(text) = identifier_text(token.r#type()) {
                         ParseResult::success(Ident {
-                            text: text.clone(),
+                            text: text.to_string(),
                             span: token.span().clone(),
                         })
                     } else {
@@ -130,12 +139,10 @@ impl Parser<Ident> for IdentParser {
     }
 
     fn can_parse(&self, stream: &dyn TokenStream) -> bool {
-        matches!(
-            stream
-                .peek_non_comment()
-                .map(crate::core::scanner::tokens::Token::r#type),
-            Some(TokenType::Identifier(_))
-        )
+        stream
+            .peek_non_comment()
+            .map(crate::core::scanner::tokens::Token::r#type)
+            .is_some_and(|token_type| identifier_text(token_type).is_some())
     }
 
     fn sync_tokens(&self) -> &[TokenType] {

--- a/src/core/parser/schema_parser.rs
+++ b/src/core/parser/schema_parser.rs
@@ -462,10 +462,7 @@ impl DefaultSchemaParser {
                 TokenType::Model
                 | TokenType::Enum
                 | TokenType::DataSource
-                | TokenType::Generator
-                | TokenType::Type
-                    if !in_block =>
-                {
+                | TokenType::Generator => {
                     if in_block && !current.is_empty() {
                         blocks.push(Block {
                             index: next_index,
@@ -477,6 +474,27 @@ impl DefaultSchemaParser {
                     in_block = true;
                     brace_depth = 0;
                     // Prepend any pending docs to the new block
+                    if !pending_docs.is_empty() {
+                        current.append(&mut pending_docs);
+                    }
+                    current.push(token.clone());
+                }
+                TokenType::Type
+                    if !in_block
+                        || Self::is_top_level_type_decl_start(
+                            stream, offset,
+                        ) =>
+                {
+                    if in_block && !current.is_empty() {
+                        blocks.push(Block {
+                            index: next_index,
+                            tokens: current,
+                        });
+                        next_index += 1;
+                        current = Vec::new();
+                    }
+                    in_block = true;
+                    brace_depth = 0;
                     if !pending_docs.is_empty() {
                         current.append(&mut pending_docs);
                     }
@@ -521,6 +539,43 @@ impl DefaultSchemaParser {
         }
 
         blocks
+    }
+
+    fn is_top_level_type_decl_start(
+        stream: &dyn TokenStream,
+        offset: usize,
+    ) -> bool {
+        matches!(
+            Self::peek_ahead_non_comment(stream, offset + 1, 0)
+                .map(Token::r#type),
+            Some(TokenType::Identifier(_))
+        ) && matches!(
+            Self::peek_ahead_non_comment(stream, offset + 1, 1)
+                .map(Token::r#type),
+            Some(TokenType::Assign)
+        )
+    }
+
+    fn peek_ahead_non_comment<'a>(
+        stream: &'a dyn TokenStream,
+        mut raw_offset: usize,
+        mut target_offset: usize,
+    ) -> Option<&'a Token> {
+        while let Some(token) = stream.peek_ahead(raw_offset) {
+            match token.r#type() {
+                TokenType::Comment(_) | TokenType::DocComment(_) => {
+                    raw_offset += 1;
+                }
+                _ => {
+                    if target_offset == 0 {
+                        return Some(token);
+                    }
+                    target_offset -= 1;
+                    raw_offset += 1;
+                }
+            }
+        }
+        None
     }
 }
 
@@ -1099,6 +1154,50 @@ mod tests {
         assert!(matches!(schema.declarations[0], Declaration::Model(_)));
         assert!(matches!(schema.declarations[1], Declaration::Enum(_)));
         assert!(res.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn identify_blocks_keeps_type_field_inside_model_block() {
+        let toks = vec![
+            t(TokenType::Model),
+            ident("AvailabilityOverride"),
+            t(TokenType::LeftBrace),
+            t(TokenType::Type),
+            ident("AvailabilityOverrideType"),
+            t(TokenType::RightBrace),
+            t(TokenType::EOF),
+        ];
+        let stream = VectorTokenStream::new(toks);
+
+        let blocks = DefaultSchemaParser::identify_blocks(&stream);
+        assert_eq!(blocks.len(), 1);
+        assert!(matches!(blocks[0].tokens[0].r#type(), TokenType::Model));
+    }
+
+    #[test]
+    fn identify_blocks_recovers_when_new_declaration_starts_mid_block() {
+        let toks = vec![
+            t(TokenType::Model),
+            ident("Broken"),
+            t(TokenType::LeftBrace),
+            ident("id"),
+            t(TokenType::Int),
+            t(TokenType::Model),
+            ident("Recovered"),
+            t(TokenType::LeftBrace),
+            t(TokenType::RightBrace),
+            t(TokenType::EOF),
+        ];
+        let stream = VectorTokenStream::new(toks);
+
+        let blocks = DefaultSchemaParser::identify_blocks(&stream);
+        assert_eq!(blocks.len(), 2);
+        assert!(matches!(blocks[0].tokens[0].r#type(), TokenType::Model));
+        assert!(matches!(blocks[1].tokens[0].r#type(), TokenType::Model));
+        assert!(matches!(
+            blocks[1].tokens[1].r#type(),
+            TokenType::Identifier(name) if name == "Recovered"
+        ));
     }
 
     #[test]

--- a/src/core/parser/schema_parser.rs
+++ b/src/core/parser/schema_parser.rs
@@ -556,11 +556,11 @@ impl DefaultSchemaParser {
         )
     }
 
-    fn peek_ahead_non_comment<'a>(
-        stream: &'a dyn TokenStream,
+    fn peek_ahead_non_comment(
+        stream: &dyn TokenStream,
         mut raw_offset: usize,
         mut target_offset: usize,
-    ) -> Option<&'a Token> {
+    ) -> Option<&Token> {
         while let Some(token) = stream.peek_ahead(raw_offset) {
             match token.r#type() {
                 TokenType::Comment(_) | TokenType::DocComment(_) => {

--- a/src/core/parser/schema_parser.rs
+++ b/src/core/parser/schema_parser.rs
@@ -463,7 +463,9 @@ impl DefaultSchemaParser {
                 | TokenType::Enum
                 | TokenType::DataSource
                 | TokenType::Generator
-                | TokenType::Type => {
+                | TokenType::Type
+                    if !in_block =>
+                {
                     if in_block && !current.is_empty() {
                         blocks.push(Block {
                             index: next_index,

--- a/src/core/scanner/lexer.rs
+++ b/src/core/scanner/lexer.rs
@@ -784,7 +784,7 @@ impl TokenRecognizer for StringLiteralRecognizer {
 
         while let Some(ch) = input.current() {
             if ch == '"' {
-                if backslash_run % 2 == 0 {
+                if backslash_run.is_multiple_of(2) {
                     input.advance(); // closing quote
                     return Ok(TokenType::Literal(content));
                 }
@@ -1781,7 +1781,7 @@ mod tests {
         let tokens: Result<Vec<_>, _> = Lexer::tokenize(input).collect();
         let tokens = tokens.unwrap();
 
-        let expected_types = vec![
+        let expected_types = [
             TokenType::Model,
             TokenType::Identifier("User".to_string()),
             TokenType::LeftBrace,


### PR DESCRIPTION
## What changed

This PR fixes several parser issues that showed up when running against a larger Prisma schema and then tightens a few related parser/scanner edges that were uncovered by review and push-hook validation.

The main parser changes are:
- make expression parsing compatible with scanner-produced literal tokens
- allow named arguments inside expression-level function calls
- treat `type` as a contextual identifier where Prisma allows it
- skip inline comments while parsing declaration bodies
- preserve schema block recovery when malformed input is missing a closing brace
- correctly recognize signed and exponent numeric literals

The PR also includes a small follow-up for existing clippy hook blockers in nearby parser/scanner code so the branch can pass the repository push hook.

## Why it changed

The original parser was producing large numbers of diagnostics on a real Prisma schema because of a few mismatches between scanner output and parser expectations:
- string literals were classified based on still having surrounding quotes, but the scanner strips those quotes
- function-call parsing only handled positional arguments, which broke forms like `createdAt(sort: Desc)`
- `type` was treated too eagerly as a hard keyword instead of a contextual identifier in field-like positions
- block splitting logic regressed when trying to avoid misclassifying `type` fields, which could hide later declarations after an unterminated block

Review then identified two correctness issues in the first pass of the fix:
- signed/scientific numeric literals could be silently misclassified as strings
- top-level block recovery on malformed input needed to be restored

## Impact

For parser users, this should significantly reduce false diagnostics on valid Prisma schemas and avoid silent AST corruption for numeric literals.

For maintainers, the changes are covered with focused unit tests in the parser expression and schema parser suites, rather than machine-specific schema fixtures.

## Validation

I ran:
- `cargo +stable test core::parser::components::expressions --lib`
- `cargo +stable test core::parser::schema_parser --lib`
- `cargo +stable test core::parser::components::helpers --lib`
- `cargo +stable test core::scanner::lexer --lib`

The branch also passed the repository push hook, including clippy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed string literal termination logic when handling escaped quotes
  * Corrected numeric parsing to properly recognize scientific notation and negative numbers

* **Improvements**
  * Enhanced comment handling within declaration blocks to prevent parsing errors
  * Better contextual keyword recognition in appropriate schema positions
  * Improved function call argument parsing robustness
  * More accurate array literal detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->